### PR TITLE
feat[subscription]

### DIFF
--- a/src/Facades/Subscription/Subscription.php
+++ b/src/Facades/Subscription/Subscription.php
@@ -60,12 +60,6 @@ class Subscription extends Base
         if (empty($this->billetData) && empty($this->cardData)) {
             throw new \Exception("Billing form not decided!");
         }
-        
-        if(!$date) {
-            $dateFormater = new DateTime();
-            $dateFormater->setTime(0, 0, 0);
-            $date = $dateFormater->format('Y-m-d\TH:i:s\Z');
-        }
 
         $data = array_merge(
             [
@@ -73,6 +67,7 @@ class Subscription extends Base
                 "customer_id" => $clientId,
                 "start_at" => $date
             ],
+            $date ? ['start_at' => $date] : [],
             $this->billetData,
             $this->cardData
         );

--- a/src/Facades/Subscription/Subscription.php
+++ b/src/Facades/Subscription/Subscription.php
@@ -2,7 +2,6 @@
 
 namespace Felipe\LaravelPagarMe\Facades\Subscription;
 
-use Felipe\LaravelPagarMe\Entities\Client;
 use Felipe\LaravelPagarMe\Facades\Base;
 
 class Subscription extends Base
@@ -29,7 +28,7 @@ class Subscription extends Base
     }
 
     public function create(
-        Client $client,
+        string $clientId,
         string $planId,
         string $paymentMethod = "credit_card",
         string $holderName,
@@ -39,7 +38,7 @@ class Subscription extends Base
         int $expirationMonth,
         string $cvv,
     ) {
-        if (!$client->id){
+        if (!$clientId){
             throw new \Exception("Client not created!");
         }
 
@@ -47,7 +46,7 @@ class Subscription extends Base
             [
                 "plan_id" => $planId,
                 "payment_method" => $paymentMethod,
-                "customer_id" => $client->id,
+                "customer_id" => $clientId,
                 "card" => [
                     "holder_name" => $holderName,
                     "holder_document" => $holderDocument,

--- a/src/Facades/Subscription/Subscription.php
+++ b/src/Facades/Subscription/Subscription.php
@@ -2,6 +2,7 @@
 
 namespace Felipe\LaravelPagarMe\Facades\Subscription;
 
+use Carbon\Carbon;
 use DateTime;
 use Felipe\LaravelPagarMe\Facades\Base;
 
@@ -51,7 +52,7 @@ class Subscription extends Base
     public function create(
         string $clientId,
         string $planId,
-        ?string $date = null
+        ?Carbon $date = null
     ) {
         if (!$clientId){
             throw new \Exception("Client not created!");
@@ -65,9 +66,8 @@ class Subscription extends Base
             [
                 "plan_id" => $planId,
                 "customer_id" => $clientId,
-                "start_at" => $date
             ],
-            $date ? ['start_at' => $date] : [],
+            $date ? ['start_at' => $date->startOfDay()->format('Y-m-d\TH:i:s\Z')] : [],
             $this->billetData,
             $this->cardData
         );

--- a/src/Facades/Subscription/Subscription.php
+++ b/src/Facades/Subscription/Subscription.php
@@ -56,6 +56,11 @@ class Subscription extends Base
         if (!$clientId){
             throw new \Exception("Client not created!");
         }
+
+        if (empty($this->billetData) && empty($this->cardData)) {
+            throw new \Exception("Billing form not decided!");
+        }
+        
         if(!$date) {
             $dateFormater = new DateTime();
             $dateFormater->setTime(0, 0, 0);

--- a/src/Facades/Subscription/Subscription.php
+++ b/src/Facades/Subscription/Subscription.php
@@ -79,4 +79,22 @@ class Subscription extends Base
         return json_decode($result, true);
     }
 
+    public function changeBillingDate(
+        string $subscriptionId,
+        string $newDate #"2022-01-25"
+    ) {
+        $result = $this->client->patch("/core/v5/subscriptions/$subscriptionId/billing-date", [
+            "next_billing_at" => $newDate
+        ])->getBody()->getContents();
+
+        return json_decode($result, true);
+    }
+
+    public function cancelSubscription(
+        string $subscriptionId
+    ) {
+        $result = $this->client->delete("/core/v5/subscriptions/$subscriptionId")->getBody()->getContents();
+
+        return json_decode($result, true);
+    }
 }


### PR DESCRIPTION
No caso de for utilizar o mesmo cliente para uma nova cobrança, ter a necessidade de criar o cliente novamente para gerar ela é redundante, alterei para solicitar apenas o Id do cliente na hora da criação.

Extraindo também a  necessidade de colocar os dados do cartão na criação para um método, e adicionado uma validação para ver se foi informado os dados do cartão ou do boleto.

Adicionando a possibilidade de informar a data de inicio.